### PR TITLE
angular dependency resolution in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,5 +28,8 @@
   "devDependencies": {
     "angular-mocks": "~1.2.16",
     "angular-scenario": "~1.2.16"
+  },
+  "resolutions": {
+    "angular": "1.2.29"
   }
 }


### PR DESCRIPTION
I'm not familiar with frontend stuff; is this ok? `bower update` fails with this

```
Unable to find a suitable version for angular, please choose one:
    1) angular#1.2.29 which resolved to 1.2.29 and is required by angular-mocks#1.2.29, angular-resource#1.2.29, angular-route#1.2.29, angular-scenario#1.2.29
    2) angular#~1.2.16 which resolved to 1.2.29 and is required by ooni-api
    3) angular#~1.2.0 which resolved to 1.2.29 and is required by angular-typewrite#0.0.4
    4) angular#>=1.0.8 which resolved to 1.4.8 and is required by angular-datamaps#0.1.2
    5) angular#>=1.2.16 1.4.x which resolved to 1.4.8 and is required by angular-ui-grid#3.0.7

Prefix the choice with ! to persist it to bower.json
```

So I hit `!1`. Makes the deploy easier.